### PR TITLE
feat: disable react/prop-types rule in ESLint config

### DIFF
--- a/index.js
+++ b/index.js
@@ -74,7 +74,10 @@ export default tseslint.config(
       '@typescript-eslint/no-unsafe-return': 'off',
       '@typescript-eslint/no-unsafe-call': 'off',
       '@typescript-eslint/no-unsafe-member-access': 'off',
-      '@typescript-eslint/no-unsafe-assignment': 'off'
+      '@typescript-eslint/no-unsafe-assignment': 'off',
+
+      // Disable prop-types rule as we're using TypeScript
+      'react/prop-types': 'off',
     }
   },
   {


### PR DESCRIPTION
Disabled the 'react/prop-types' rule in the ESLint configuration as we are using TypeScript for type checking. This change helps to avoid redundant warnings.